### PR TITLE
Fixes for Runelite Update

### DIFF
--- a/src/main/java/com/raidsdrymeter/RaidsDryMeterPlugin.java
+++ b/src/main/java/com/raidsdrymeter/RaidsDryMeterPlugin.java
@@ -217,7 +217,7 @@ public class RaidsDryMeterPlugin extends Plugin
 			drops = convertToUniqueRecords(event.getItems());
 
 			int totalPoints = client.getVarbitValue(Varbits.TOTAL_POINTS);
-			int personalPoints = client.getVarbitValue(Varbits.PERSONAL_POINTS);
+			int personalPoints = client.getVarpValue(VarPlayer.RAIDS_PERSONAL_POINTS);
 
 			for (int uniqueId : UniqueItem.getUniqueItemList(itemManager)){
 				for(ItemStack item : event.getItems())


### PR DESCRIPTION
Fixes issues related to the Varbits.PERSONAL_POINTS being replaced VarPlayer.RAID_PERSONAL_POINTS (now varp instead of varbit).

Read more here:
https://github.com/runelite/runelite/commit/b7ec9ea557834bf48bf0231c07ef519bea05635d#diff-64b67ae1bed9c77c1eec0b40fc51b537b9526f8555c217e66e475af70a5fa32bL318